### PR TITLE
Fix characters being removed from paths

### DIFF
--- a/health.sh
+++ b/health.sh
@@ -57,10 +57,10 @@ fi
 # Variables
 #------------------------------------------------------------------------------
 CURRENT_FOLDER=$(dirname "$0")
-LOGS_FOLDER=$(cat "$CURRENT_FOLDER"/config.cfg | grep LOGS_FOLDER | tr -d 'LOGS_FOLDER=')
-CONFIGS_FOLDER=$(cat "$CURRENT_FOLDER"/config.cfg | grep CONFIGS_FOLDER | tr -d 'CONFIGS_FOLDER=')
-WATCHDOG_LOG=$(cat "$CURRENT_FOLDER"/config.cfg | grep WATCHDOG_LOG | tr -d 'WATCHDOG_LOG=')
-EMAIL=$(cat "$CURRENT_FOLDER"/config.cfg | grep EMAIL | tr -d 'EMAIL=')
+LOGS_FOLDER=$(cat "$CURRENT_FOLDER"/config.cfg | grep ^LOGS_FOLDER= | sed 's/^LOGS_FOLDER=//')
+CONFIGS_FOLDER=$(cat "$CURRENT_FOLDER"/config.cfg | grep ^CONFIGS_FOLDER= | sed 's/^CONFIGS_FOLDER=//')
+WATCHDOG_LOG=$(cat "$CURRENT_FOLDER"/config.cfg | grep ^WATCHDOG_LOG= | sed 's/^WATCHDOG_LOG=//')
+EMAIL=$(cat "$CURRENT_FOLDER"/config.cfg | grep ^EMAIL= | sed 's/^EMAIL=//')
 VER='b1.1.0'
 HOSTNAME=$(hostname)
 YEAR=$(date +%Y)


### PR DESCRIPTION
tr does character based replacement so the old code would remove underscores and the various capital letters from the paths.  sed pulls the exact string out and nothing else.